### PR TITLE
Fix ENABLE_STEAL_SKILL Toggle

### DIFF
--- a/Engine Hacks/SkillSystem/Skills/UnitMenuSkills/StealPlus/StealPlus/StealPlus.event
+++ b/Engine Hacks/SkillSystem/Skills/UnitMenuSkills/StealPlus/StealPlus/StealPlus.event
@@ -92,3 +92,5 @@ WORD WatchfulID
 	WORD StealID
 	WORD StealPlusID
 	
+#endif
+	


### PR DESCRIPTION
A missing #endif caused build errors when this was commented out.