### PR TITLE
Actual boosts fix

### DIFF
--- a/Custom Definitions.event
+++ b/Custom Definitions.event
@@ -23,7 +23,7 @@
 // (which is sadly what the included table also does TODO: fix that)
 #define PassiveBoosts 0x80
 
-#define StatBonus(HPB,StrB,MagB,SklB,SpdB,DefB,ResB,LckB,MovB,ConB) "BYTE HPB StrB SklB SpdB DefB ResB LckB MovB ConB MagB 0x0 0x0"
+#define StatBonus(HPB,StrB,MagB,SklB,SpdB,DefB,ResB,LckB,MovB,ConB) "BYTE HPB StrB SklB SpdB DefB ResB LckB MovB ConB MagB 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0"
 
 #define GrowthBonus(HPB,StrB,MagB,SklB,SpdB,DefB,ResB,LckB) "BYTE 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 HPB StrB SklB SpdB DefB ResB LckB MagB 0x0 0x0"
 

--- a/Custom Definitions.event
+++ b/Custom Definitions.event
@@ -23,6 +23,10 @@
 // (which is sadly what the included table also does TODO: fix that)
 #define PassiveBoosts 0x80
 
+#define StatBonus(HPB,StrB,MagB,SklB,SpdB,DefB,ResB,LckB,MovB,ConB) "BYTE HPB StrB SklB SpdB DefB ResB LckB MovB ConB MagB 0x0 0x0"
+
+#define GrowthBonus(HPB,StrB,MagB,SklB,SpdB,DefB,ResB,LckB) "BYTE 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 0x0 HPB StrB SklB SpdB DefB ResB LckB MagB 0x0 0x0"
+
 #include "Engine Hacks/SkillSystem/skill_definitions.event"
 
 // #define __DEBUG__ // Uncomment to get the Debug startup menu :p

--- a/Engine Hacks/Necessary/MSG/HelperDefinitions.event
+++ b/Engine Hacks/Necessary/MSG/HelperDefinitions.event
@@ -129,8 +129,8 @@
 #define STAT_DEFENSE    0x04
 #define STAT_RESISTANCE 0x05
 #define STAT_LUCK       0x06
-#define STAT_CON        0x07
-#define STAT_MOV        0x08
+#define STAT_MOV        0x07
+#define STAT_CON        0x08
 
 // Class/Char Attribute Flags (comes straight from BOOTS)
 #define CA_NONE                  0x00000000


### PR DESCRIPTION
MSG helper definitions swap the indexes of con and mag from how it is laid out in vanilla, so this corrects this. Also adds macros for setting stat and growth boosts as an example of how this should be laid out.