### PR TITLE
Fix HP boost healing

### DIFF
--- a/Engine Hacks/Necessary/MSG/3rdParty/InjectHPGetters.event
+++ b/Engine Hacks/Necessary/MSG/3rdParty/InjectHPGetters.event
@@ -1,0 +1,17 @@
+#ifndef MSG_INJECT_HP_GETTERS_EVENT
+#define MSG_INJECT_HP_GETTERS_EVENT
+
+// some vanilla functions don't use HP getters (at least the healing one, possibly more) so this is to make it use them
+
+PUSH
+
+	ORG $193A4 //UnitTryHeal
+	SHORT $B570 $1C04 $1C0D
+	BYTE $FF $F7 $D1 $FE
+	SHORT $1C06 $1C20
+	BYTE $FF $F7 $ED $FE
+	SHORT $1C03 $1C30 $1940 $4298 $DD00 $1C18 $74E0 $BC70 $BC01 $4700
+
+POP
+
+#endif // MSG_INJECT_HP_GETTERS_EVENT

--- a/Engine Hacks/Necessary/MSG/InstallCore.event
+++ b/Engine Hacks/Necessary/MSG/InstallCore.event
@@ -12,6 +12,7 @@
 
 #include "3rdParty/InjectMovGetters.event"
 #include "3rdParty/InjectConGetters.event"
+#include "3rdParty/InjectHPGetters.event"
 #include "3rdParty/Comparators.event"
 
 PUSH


### PR DESCRIPTION
The function used for evaluating `(healing amount + cur HP) <= max HP)` for purposes of not letting HP overflow when healing didn't use HP stat getters, this rewrites that function to use them. The previous version of the function checked equipped weapon stat boosts manually, so those would still work as expected; now every HP boost will work.