### PR TITLE
Config option to not use test map

### DIFF
--- a/Engine Hacks/Config.event
+++ b/Engine Hacks/Config.event
@@ -7,6 +7,10 @@
 #define SHOW_SKILL_WARNING
 
 
+// If commented, the test map will not be installed.
+#define USE_TEST_MAP
+
+
 // ===================================
 // = HACK INSTALLATION CONFIGURATION =
 // ===================================

--- a/Events/Release_map.event
+++ b/Events/Release_map.event
@@ -15,6 +15,14 @@ EventPointerTable(0x7, PointerList)
 VeinEffect(0, FreezeAllEnemies)
 #endif // DRAGON_VEINS
 
+setText(0x160, NewChName)
+
+ALIGN 4
+NewChName:
+String("Boss Rush")
+BYTE 0
+
+ALIGN 4
 PointerList:
 POIN TurnBasedEvents
 POIN CharacterBasedEvents

--- a/ROM Buildfile.event
+++ b/ROM Buildfile.event
@@ -18,13 +18,15 @@
     #include "Engine Hacks/_MasterHackInstaller.event"
     MESSAGE Used hax space ends at currentOffset
 
+	#ifdef USE_TEST_MAP
     //Events
     #include "Events/Release_map.event"
     #include "Events/WorldMapEvents.event"
 
     //Maps
     #include "Maps/Master Map Installer.event"
-    
+    #endif // USE_TEST_MAP
+	
     MESSAGE Used free space ends at currentOffset
 #else
     ERROR You are not assembling FE8 events!

--- a/Text/text_buildfile.txt
+++ b/Text/text_buildfile.txt
@@ -8,9 +8,6 @@ HP Bars[.][X]
 # 0x00B2
 Set health bar display[X]
 
-# 0x160 PrologueChName
-Boss Rush[X]
-
 #0x3A LearnedSkillText
 #first text ID in the free block
 Learned  [X]


### PR DESCRIPTION
Also changes how the `Boss Rush` text is installed so it only shows up if the Boss Rush map is installed. Since this isn't really engine hack related, considering moving `Config.event` to the root at some point.