### PR TITLE
Update SpellSystemASM.s

### DIFF
--- a/EngineHacks/ExternalHacks/GaidenMagic/SpellSystemASM.s
+++ b/EngineHacks/ExternalHacks/GaidenMagic/SpellSystemASM.s
@@ -26,15 +26,22 @@ mov r6, r8
 push { r6, r7 }
 mov r5, r0
 mov r3, r1
-mov r0, #0x1 	@ 
-neg r0, r0  	@ These 4 lines were commented out for some reason by Snek 
-cmp r3, r0	@ but they cause an AI bug where they always use their last inv wep 
-bne EnemyExists @ so I uncommented them - Vesly 
-	CheckWeaponSlot:
-	mov r0, r5
-	blh GetUnitEquippedWeaponSlot, r1
-	mov r3, r0
+
+CheckWeaponSlot:
+push {r3} 
+@mov r0, r5
+blh GetUnitEquippedWeaponSlot, r1
+pop {r3} 
+cmp r0, #9 
+beq OverwriteR3
+mov r1, #0x1 	@ 
+neg r1, r1  	@ These 4 lines were commented out for some reason by Snek 
+cmp r3, r1		@ but they cause an AI bug where they always use their last inv wep 
+bne EnemyExists @ so I uncommented them - Vesly 	
+OverwriteR3:
+mov r3, r0
 EnemyExists:
+
 ldr r0, [ r5, #0xC ]
 mov r1, #0x80
 lsl r1, r1, #0x4

--- a/EngineHacks/ExternalHacks/GaidenMagic/SpellSystemASM.s
+++ b/EngineHacks/ExternalHacks/GaidenMagic/SpellSystemASM.s
@@ -26,10 +26,10 @@ mov r6, r8
 push { r6, r7 }
 mov r5, r0
 mov r3, r1
-@mov r0, #0x1
-@neg r0, r0
-@cmp r3, r0
-@bne EnemyExists
+mov r0, #0x1 	@ 
+neg r0, r0  	@ These 4 lines were commented out for some reason by Snek 
+cmp r3, r0	@ but they cause an AI bug where they always use their last inv wep 
+bne EnemyExists @ so I uncommented them - Vesly 
 	CheckWeaponSlot:
 	mov r0, r5
 	blh GetUnitEquippedWeaponSlot, r1
@@ -99,7 +99,8 @@ mov r8, r4
 mov r4, r2
 ldr r1, =#0x802A84B
 bx r1
-.ltorg
+
+.ltorg
 
 .global GaidenActionStaffDoorChestUseItemHack
 .type GaidenActionStaffDoorChestUseItemHack, %function
@@ -129,7 +130,8 @@ ActionFixUsingSpell:
 EndActionFix:
 ldr r1, =#0x0802FC63
 bx r1
-.ltorg
+
+.ltorg
 .global GaidenPreActionHack
 .type GaidenPreActionHack, %function
 GaidenPreActionHack: @ Autohook to 0x0801D1D0.
@@ -151,7 +153,8 @@ PreActionFixUsingSpell:
 EndPreActionFix:
 ldr r0, =#0x0801D1E1
 bx r0
-.ltorg
+
+.ltorg
 .global GaidenSetupBattleUnitForStaffHack
 .type GaidenSetupBattleUnitForStaffHack, %function
 GaidenSetupBattleUnitForStaffHack: @ Autohook to 0x0802CB24.
@@ -220,7 +223,8 @@ SetupBattleUnitForStaffUsingSpell:
 EndSetupBattleUnitForStaffFix:
 ldr r0, =#0x0802CB4B
 bx r0
-.ltorg
+
+.ltorg
 
 .global GaidenExecStandardHealHack
 .type GaidenExecStandardHealHack, %function
@@ -246,7 +250,8 @@ ldrb r1, [ r1 ]
 EndExecStandardHeal:
 ldr r0, =#0x0802EBCD
 bx r0
-.ltorg
+
+.ltorg
 
 .global GaidenExecFortifyHack
 .type GaidenExecFortifyHack, %function
@@ -269,7 +274,8 @@ ldrb r1, [ r1 ]
 EndExecFortify:
 ldr r0, =#0x0802F195
 bx r0
-.ltorg
+
+.ltorg
 
 .global GaidenStaffInventoryHack
 .type GaidenStaffInventoryHack, %function
@@ -298,7 +304,8 @@ bne SkipStaffInventory
 SkipStaffInventory:
 ldr r0, =#0x0802CCB3
 bx r0
-.ltorg
+
+.ltorg
 .global GaidenTargetSelectionBPressHack
 .type GaidenTargetSelectionBPressHack, %function
 GaidenTargetSelectionBPressHack: @ Autohook to 0x08022780. Unset spell variables when B pressing on target selection.
@@ -311,7 +318,8 @@ bl GaidenZeroOutSpellVariables
 mov r0, #0x19
 pop { r1 }
 bx r1
-.ltorg
+
+.ltorg
 
 .global GaidenTargetSelectionCamWaitBPressHack
 .type GaidenTargetSelectionCamWaitBPressHack, %function
@@ -324,7 +332,8 @@ bl GaidenZeroOutSpellVariables
 mov r0, #0x19
 pop { r1 }
 bx r1
-.ltorg
+
+.ltorg
 
 .global GaidenMenuSpellCostHack
 .type GaidenMenuSpellCostHack, %function


### PR DESCRIPTION
mov r0, #0x1 	@ 
neg r0, r0  	@ These 4 lines were commented out for some reason by Snek 
cmp r3, r0		@ but they cause an AI bug where they always use their last inv wep 
bne EnemyExists @ so I uncommented them - Vesly 