### PR TITLE
Remove skill reorder warning

### DIFF
--- a/EngineHacks/Config.event
+++ b/EngineHacks/Config.event
@@ -7,9 +7,6 @@
 // = GENERAL CONFIGURATION =
 // =========================
 
-// If commented, the skill reorder warning will not be displayed.
-#define SHOW_SKILL_WARNING
-
 // If commented, the test map will not be installed.
 #define USE_TEST_MAP
 

--- a/EngineHacks/SkillSystem/SkillSystemInstaller.event
+++ b/EngineHacks/SkillSystem/SkillSystemInstaller.event
@@ -21,10 +21,3 @@
 
 #include "SkillScrolls/SkillScrolls.event"
 
-
-#ifdef SHOW_SKILL_WARNING
-	WARNING "Default skills have been reordered!"
-	WARNING "This will break existing save files made with old configs."
-	WARNING "Restore your old 'skill_definitions.event' if necessary to avoid any issues."
-	WARNING "To hide these warnings, comment out '#define SHOW_SKILL_WARNING' in 'Config.event'."
-#endif // SHOW_SKILL_WARNING


### PR DESCRIPTION
It's been 10 months it's no longer novel enough to warrant a warning