### PR TITLE
Make Bond referenced in the HP calc loop

### DIFF
--- a/EngineHacks/Necessary/CalcLoops/HPRestorationCalcLoop/HPRestorationCalcLoop.event
+++ b/EngineHacks/Necessary/CalcLoops/HPRestorationCalcLoop/HPRestorationCalcLoop.event
@@ -11,7 +11,7 @@ POP
 
 ALIGN 4
 HPRestorationLoop: //for each, r0 = unit and r1 = current heal %; return modified heal % in r0
-POIN Renewal Relief Imbue Forager Camaraderie Amaterasu
+POIN Renewal Relief Imbue Forager Camaraderie Amaterasu Bond
 #ifdef HEAL_TILES
 POIN HealTiles
 #endif // HEAL_TILES


### PR DESCRIPTION
Found another oopsie I think - it looks like `Bond` is never actually referenced in the HP calc loop. This should be all that's necessary to get it working again.