### PR TITLE
Reorder movement getter to put guard AI debuff (almost) last

### DIFF
--- a/EngineHacks/Necessary/StatGetters/Movement.event
+++ b/EngineHacks/Necessary/StatGetters/Movement.event
@@ -4,11 +4,11 @@
 #include "_Common.event"
 ALIGN 4
 pMovModifiers: // Movement
-	POIN prAddUnitBaseMov prAddUnitMovBonus (prGetItemMovBonus-1) prItemPassiveMov prRallyMov prSkillCelerity prSkillPoise prNullifyIfGuardAI prArmorMarchCheck 
+	POIN prAddUnitBaseMov prAddUnitMovBonus (prGetItemMovBonus-1) prItemPassiveMov prRallyMov prSkillCelerity prSkillPoise prArmorMarchCheck
 	#ifdef STAIRS_ASM
 	POIN StairsMoveDebuff-1
 	#endif
-	POIN prNullifyIfFreeze
+	POIN prNullifyIfFreeze prNullifyIfGuardAI
 	#ifdef DEBUFFS_MIN_ZERO
 	POIN prMinZero
 	#endif


### PR DESCRIPTION
Quick fix to the order of movement getters. Not having the guard AI debuff last caused a funny bug with armor march:
![image](https://user-images.githubusercontent.com/38043506/147858560-9e776e94-9d14-405d-bb32-216e0bd53572.png)
![image](https://user-images.githubusercontent.com/38043506/147858561-78c959e6-c21e-4805-9c37-5c9ade59b2f0.png)
