### PR TITLE
Stop non-siege weapons from using long-range animations

### DIFF
--- a/EngineHacks/_FE8EssentialFixes.event
+++ b/EngineHacks/_FE8EssentialFixes.event
@@ -46,6 +46,12 @@ POP
 //  SHORT $e00d
 //  POP
 
+//Make attacks at 2-15 range not use long-range anims by default (by Sme)
+//use the Uncounterable flag for long-range anims instead
+PUSH
+  ORG $57314
+  BYTE 0xF
+POP
 	
 //change staff battle init to not give 0xFF status on miss
   PUSH


### PR DESCRIPTION
Normally, any attack from a range of 4 or greater would always use long-range animations. This creates a problem, as Longbows & Bowrange+1 together would give 4 range and use long-range animations when it shouldn't. This changes the default behavior such that long-range animations are only applied automatically at ranges >15, something it's not normally possible to give to an item. The Uncounterable flag serves as a special case that always forces long-range animations, and is already applied to all siege weapons; as such, this does not change vanilla behavior while fixing this skill interaction's behavior.