### PR TITLE
Change gaiden spell list table to allocate 0x100 instead of 0xFF

### DIFF
--- a/EngineHacks/ExternalHacks/GaidenMagic/GaidenSpellLists.event
+++ b/EngineHacks/ExternalHacks/GaidenMagic/GaidenSpellLists.event
@@ -3,7 +3,7 @@
 
 ALIGN 4
 SpellListTable: // Allocate space for the spell list pointer table.
-FILL 4*0xFF
+FILL 4*0x100
 
 // Example usage of a spell list.
 	// Format is 0 0 terminated.


### PR DESCRIPTION
One-liner in order to fix a bug found by 7743: https://discord.com/channels/144670830150811649/894721150511374437/978378250499801138
This would cause a problem when attacking a snag (character ID 0xFF), reading beyond the end of the table. This simply raises the table allocation.