### PR TITLE
Fix mounted units not setting off mines

### DIFF
--- a/EngineHacks/SkillSystem/Skills/PostBattleSkills/PostBattleSkills.event
+++ b/EngineHacks/SkillSystem/Skills/PostBattleSkills/PostBattleSkills.event
@@ -5,6 +5,12 @@ jumpToHack(CheckGaleforce)
 //ORG $39BDC //this added 1 to make the ai move the next unit
 POP
 
+//change a strange canto bitflag check when triggering mines to a different, redundant flag
+PUSH
+ORG $37760
+BYTE 8
+POP
+
 ALIGN 4
 CheckGaleforce: //decides if the unit should be cantoing or not
 #incbin "Galeforce/checkgaleforce.dmp"


### PR DESCRIPTION
For contrived reasons involving strange vanilla code and ways the skill system changes how canto is denoted, any unit with the canto ability bitflag set would be stopped by mines but not actually set them off. This changes the bitflag checked to the thief ability bitflag, which due to a superseding check that will not stop units with that bitflag set when they cross over mines causes no change in behavior from vanilla.

Fixes #387.