### PR TITLE
Add canto skills to AuraSkillTable

### DIFF
--- a/EngineHacks/Necessary/CalcLoops/PreBattleCalcLoop/PreBattleCalcLoop.event
+++ b/EngineHacks/Necessary/CalcLoops/PreBattleCalcLoop/PreBattleCalcLoop.event
@@ -71,6 +71,8 @@ ALIGN 4
 AuraSkillTable:
 FILL 0xFF
 
+AuraSkillEntry(CantoID)
+AuraSkillEntry(CantoPlusID)
 AuraSkillEntry(CharmID)
 AuraSkillEntry(DemoiselleID)
 AuraSkillEntry(GentilhommeID)


### PR DESCRIPTION
Fixes the KeepUp skill by making canto skills count as aura skills.