### PR TITLE
repoint unit load buffer opt

### DIFF
--- a/EngineHacks/Config.event
+++ b/EngineHacks/Config.event
@@ -196,6 +196,12 @@
 // If uncommented all boss kills will play critical hit animations.
 // #define FLASHY_MODE
 
+// If uncommented, the unit load buffer will be repointed.
+// The location it is repointed to is also defined here. The default location is
+// the area that stores turn count information, and WILL break turn counts.
+// #define REPOINT_UNIT_LOAD_BUFFER
+// #define NewUnitLoadBufferLoc 0x203ED40
+
 // =================================
 // = SKILL BEHAVIOUR CONFIGURATION =
 // =================================

--- a/EngineHacks/Necessary/Debuffs/Debuffs.event
+++ b/EngineHacks/Necessary/Debuffs/Debuffs.event
@@ -190,19 +190,23 @@ TeamDebuffTables:
     ORG 0x59191C // Clear debuffs on chapter switch
       WORD $0D; POIN GameCtrlClearProc
 
-    // prevent debuffs and loading issue (Kirb)
+	#ifdef REPOINT_UNIT_LOAD_BUFFER
 
-    ORG 0xBA30
-      WORD 0x203ED40
+		// prevent debuffs and loading issue (Kirb)
 
-    ORG 0xBA54
-      WORD 0x203ED40
+		ORG 0xBA30
+		  WORD NewUnitLoadBufferLoc
 
-    ORG 0xFA34
-      WORD 0x203ED40
+		ORG 0xBA54
+		  WORD NewUnitLoadBufferLoc
 
-    ORG 0xD5B80
-      WORD 0x203ED40
+		ORG 0xFA34
+		  WORD NewUnitLoadBufferLoc
+
+		ORG 0xD5B80
+		  WORD NewUnitLoadBufferLoc
+	
+	#endif // REPOINT_UNIT_LOAD_BUFFER
 
     // new stat getters
     // see modular stat getters


### PR DESCRIPTION
makes repointing unit load buffer for not running over the debuff table a config disabled by default and also turns where it's repointed to into a definition when it is enabled. Brings back the "you need smaller unit groups to not overflow into debuff table" restriction but is also necessary to unbreak turn count tracking