### PR TITLE
Repoint load buffer to debug printing area by default

### DIFF
--- a/EngineHacks/Config.event
+++ b/EngineHacks/Config.event
@@ -205,9 +205,9 @@
 
 // If uncommented, the unit load buffer will be repointed.
 // The location it is repointed to is also defined here. The default location is
-// the area that stores turn count information, and WILL break turn counts.
-// #define REPOINT_UNIT_LOAD_BUFFER
-// #define NewUnitLoadBufferLoc 0x203ED40
+// the area used for debug printing.
+#define REPOINT_UNIT_LOAD_BUFFER
+#define NewUnitLoadBufferLoc 0x2026E30
 
 // =================================
 // = SKILL BEHAVIOUR CONFIGURATION =


### PR DESCRIPTION
Fixes #505. Since this no longer breaks functionality when enabled and causes problems when disabled, it is now enabled by default. It remains a config option in case of project-specific conflicts that would need it to be disabled.