### PR TITLE
Fix x coord of unit menu when backing out of option

### DIFF
--- a/EngineHacks/Necessary/UnitMenu/UnitMenu.event
+++ b/EngineHacks/Necessary/UnitMenu/UnitMenu.event
@@ -34,10 +34,10 @@ PUSH
   ORG $22882
     BYTE $01 // left x coord (go back 1)
 
+  */
+
   ORG $22884
     BYTE $14 // right x coord (go back 1)
-
-  */
 
   ORG $22818
     BYTE $01 // left x coord (go back 2)


### PR DESCRIPTION
Fixes #494.
`$22884` is just after the capture hook in
https://github.com/FireEmblemUniverse/SkillSystem_FE8/blob/67b7cbd8d39130a09a468b1b25eaa5a3a6e168b5/EngineHacks/SkillSystem/Skills/UnitMenuSkills/Capture/Capture/Capture.event#L33-L34 meaning it's safe to edit.