### PR TITLE
Fix unit and chapter menu defaults

### DIFF
--- a/EngineHacks/Necessary/UnitMenu/UnitMenu.event
+++ b/EngineHacks/Necessary/UnitMenu/UnitMenu.event
@@ -5,11 +5,11 @@
 #include "_UnitMenuDefs.event"
 
 #define ChapterMenuWidth 9
-#define ChapterMenuRightXCoord 17
+#define ChapterMenuRightXCoord 20
 
 #define UnitMenuWidth 9
 #define UnitMenuLeftXCoord 1
-#define UnitMenuRightXCoord 14
+#define UnitMenuRightXCoord 20
 
 PUSH
 


### PR DESCRIPTION
The current values weren't converted from hex to decimal (eg, $14 went to 14d).
The conversion is 20d. The chapter menu's x coord is also set to 20d, as that fits its new size.