### PR TITLE
Fix StrMag Rescue Arrows

### DIFF
--- a/EngineHacks/Config.event
+++ b/EngineHacks/Config.event
@@ -27,7 +27,7 @@
 // If uncommented, a full str/split will be implemented without replacing any stats
 // TODO: Define an item ID for Spirit Dust (Mag statbooster) in "Strmag/Str Mag Split/Installer.event". Energy Ring is used by default!
 // Item icon for Spirit Dust is included! Define your icon ID in "Strmag/_Master Asm Installer.event". Default is Green Note.
-//#define USE_STRMAG_SPLIT
+// #define USE_STRMAG_SPLIT
 
 // If uncommented, the statscreen will have a moving background similar to FE6 and FE7.
 // Customization of graphical assets is possible in Necessary/ModularStatScreen/Background/Graphics/Graphics.event.

--- a/EngineHacks/Necessary/ModularStatScreen/ModularStatScreen.event
+++ b/EngineHacks/Necessary/ModularStatScreen/ModularStatScreen.event
@@ -8,12 +8,23 @@
 
 #ifdef _FE8_
 
-  #define Skl_Arrow_X 0x78
-  #define Skl_Arrow_Y 0x28
-  #define Spd_Arrow_X 0x78
-  #define Spd_Arrow_Y 0x38
-  #define Trv_Icon_X 0xB8
-  #define Trv_Icon_Y 0x2E
+  #ifndef USE_STRMAG_SPLIT
+	//normal positions
+    #define Skl_Arrow_X 0x78
+    #define Skl_Arrow_Y 0x28
+    #define Spd_Arrow_X 0x78
+    #define Spd_Arrow_Y 0x38
+    #define Trv_Icon_X 0xB8
+    #define Trv_Icon_Y 0x2E
+  #else // USE_STRMAG_SPLIT
+	//strmag positions
+	#define Skl_Arrow_X 0x78
+    #define Skl_Arrow_Y 0x38
+    #define Spd_Arrow_X 0x78
+    #define Spd_Arrow_Y 0x48
+    #define Trv_Icon_X 0xB8
+    #define Trv_Icon_Y 0x2E 
+  #endif // USE_STRMAG_SPLIT
   
   #include "DisplayGrowthsOptions/DisplayGrowthsOptions.event"
   #include "WeaponRankStatScreen/WeaponRankStatScreen.event"


### PR DESCRIPTION
Though they may be somewhat redundant, the option should remain nonetheless. This conditionally puts them in a different position matching the default MSS layouts for MSS page 1 with and without strmag split installed.