### PR TITLE
Change Default FreeSpace Offset

### DIFF
--- a/CustomDefinitions.event
+++ b/CustomDefinitions.event
@@ -1,5 +1,7 @@
-#define FreeSpace 0xb2a610
-#define FreeSpaceEnd 0xC00000
+// #define FreeSpace 0xb2a610
+// #define FreeSpaceEnd 0xC00000
+#define FreeSpace 0xFE4000
+#define FreeSpaceEnd 0x2000000
 #define FreeSpaceBLRange 0x1c1ec0
 
 #define ChapterTileset(chapter, object, palette, config) "PUSH; ORG 0x8b0890 + (148* chapter) + 4; SHORT object; BYTE palette config; POP"


### PR DESCRIPTION
Changes default offset of FreeSpace to after everything referenced within the ROM, so that it will no longer overflow into the animation table and throw an error with no further information. Overflow check is still in place, but set to `0x2000000` now, as beyond that is not able to be referenced by the GBA.