### PR TITLE
Address unintuitive macro expansion

### DIFF
--- a/EngineHacks/Necessary/Debuffs/Debuffs.event
+++ b/EngineHacks/Necessary/Debuffs/Debuffs.event
@@ -190,9 +190,9 @@ ASSERT (DebuffAssertTable+DebuffEntrySize)-DebuffTooBig
 
 TeamDebuffTables:
   {
-  #define MaxPlayerUnits 62+1
-  #define MaxEnemyUnits 50+1
-  #define MaxGreenUnits 20+1
+  #define MaxPlayerUnits "(62+1)"
+  #define MaxEnemyUnits "(50+1)"
+  #define MaxGreenUnits "(20+1)"
   
   #define PUDebuffTable DebuffTableRam
   #define EUDebuffTable "PUDebuffTable + (MaxPlayerUnits*DebuffEntrySize)"


### PR DESCRIPTION
This will eventually be necessary because of the version of ColorzCore I am working on (see https://github.com/FireEmblemUniverse/ColorzCore/pull/63), which hopefully will make it as an "official" release, will break this.

# Explanation

    #define MaxPlayerUnits 62+1
    // ...
    #define EUDebuffTable "PUDebuffTable + (MaxPlayerUnits*DebuffEntrySize)"
    // ...
    WORD EUDebuffTable

Because of a quirk in the current version of ColorzCore, the body of the object-like macro "MaxPlayerUnits" is evaluated early as a number, and results in the single token "0x3F" (63) at definition time.

This results eventually in the following statement when expanded:

    WORD PUDebuffTable + (0x3F*DebuffEntrySize)

(keeping macro names for the parts that aren't relevant for clarity)

Now, I made a change to the way '#define' works that allows it to take any sequence of tokens as macro body, not just an expression or a string. I believe it's an improvement but is means that the body of "MaxPlayerUnits" is cannot be evaluated early anymore, and keeps being the sequence ["62", "+", "1"].

Eventually, when expanded:

    WORD PUDebuffTable + (62+1*DebuffEntrySize)

This is not the same as above because of operator precedence.

Notes:
- this would probably also be broken in legacy NL!Core.
- this would also be broken in the C preprocessor.
- this would also be broken if you put quotes around the definitions (`#define MaxPlayerUnits "62+1"` breaks)

(I might have to add some hacks in ColorzCore to at least warn users of such cases when they upgrade).

# The fix

Put parenthesizes around the expression in the definition. I also added quotes for good measure.