### PR TITLE
Fix Provoke

### DIFF
--- a/EngineHacks/SkillSystem/Skills/AISkills/AISkills.event
+++ b/EngineHacks/SkillSystem/Skills/AISkills/AISkills.event
@@ -1,6 +1,9 @@
 PUSH
 
 //Provoke
+ORG $3DF40
+SHORT 0x2132 0xE018 // fix provoke not working when skill holder can die
+
 ORG $3DF78
 jumpToHack(Provoke)
 


### PR DESCRIPTION
When a unit with provoke can be killed, the provocation doesn't work and other units can be targeted.

This fixes this issue by no longer branching over the provoke hook when the unit can be killed.